### PR TITLE
[1.20] Add Phase and Day Options, per #7

### DIFF
--- a/common/src/main/java/com/mrbysco/lunar/LunarPhaseData.java
+++ b/common/src/main/java/com/mrbysco/lunar/LunarPhaseData.java
@@ -63,6 +63,7 @@ public class LunarPhaseData extends SavedData {
 
 	public void setRandomLunarEvent(Level level) {
 		if (forcedEvent != null) {
+			//Technically, this code block is redundant given setRandomLunarEvent is evaluated last, but I figured I'd keep it just in case something changes down the line.
 			Component startComponent = Component.translatable("lunar.event.start", Component.translatable(forcedEvent.getTranslationKey()));
 			level.players().forEach(player -> player.sendSystemMessage(startComponent));
 			setActiveEvent(forcedEvent);
@@ -79,6 +80,53 @@ public class LunarPhaseData extends SavedData {
 				}
 			}
 			setDefaultMoon();
+		}
+	}
+
+	public boolean setPhaseEvent(Level level) {
+		if(!LunarRegistry.instance().phaseConfigured())
+			return false;
+
+		if (forcedEvent != null){
+			Component startComponent = Component.translatable("lunar.event.start", Component.translatable(forcedEvent.getTranslationKey()));
+			level.players().forEach(player -> player.sendSystemMessage(startComponent));
+			setActiveEvent(forcedEvent);
+			setForcedEvent(null);
+			return true;
+		} else {
+			ILunarEvent event = LunarRegistry.instance().getPhaseEvent(level);
+
+			if(event != null){
+				Component startComponent = Component.translatable("lunar.event.start", Component.translatable(event.getTranslationKey()));
+				level.players().forEach(player -> player.sendSystemMessage(startComponent));
+				setActiveEvent(event);
+				return true;
+			}
+			return false;
+		}
+	}
+
+	public boolean setDayEvent(Level level) {
+		if(!LunarRegistry.instance().dayConfigured())
+			return false;
+
+		if (forcedEvent != null){
+			//Technically, this code block is redundant given setDayEvent comes after setPhaseEvent, but I figured I'd keep it just in case something changes down the line.
+			Component startComponent = Component.translatable("lunar.event.start", Component.translatable(forcedEvent.getTranslationKey()));
+			level.players().forEach(player -> player.sendSystemMessage(startComponent));
+			setActiveEvent(forcedEvent);
+			setForcedEvent(null);
+			return true;
+		} else {
+			ILunarEvent event = LunarRegistry.instance().getDayEvent(level);
+
+			if(event != null){
+				Component startComponent = Component.translatable("lunar.event.start", Component.translatable(event.getTranslationKey()));
+				level.players().forEach(player -> player.sendSystemMessage(startComponent));
+				setActiveEvent(event);
+				return true;
+			}
+			return false;
 		}
 	}
 

--- a/common/src/main/java/com/mrbysco/lunar/api/ILunarEvent.java
+++ b/common/src/main/java/com/mrbysco/lunar/api/ILunarEvent.java
@@ -61,6 +61,20 @@ public interface ILunarEvent {
 	int spawnWeight();
 
 	/**
+	 * The phase of the moon in which the lunar event will always be picked.
+	 *
+	 * @return The moon phase, -1 being disabled and 0-7 being corresponding phases (min -1, max 7)
+	 */
+	int getPhase();
+
+	/**
+	 * The nth day in which the lunar event will always be picked.
+	 *
+	 * @return The nth day, 0 being disabled and 255 the maximum (min 0, max 255)
+	 */
+	int getDay();
+
+	/**
 	 * The color of the moon during the lunar event.
 	 *
 	 * @return the color of the moon

--- a/common/src/main/java/com/mrbysco/lunar/handler/LunarHandler.java
+++ b/common/src/main/java/com/mrbysco/lunar/handler/LunarHandler.java
@@ -3,6 +3,7 @@ package com.mrbysco.lunar.handler;
 import com.mrbysco.lunar.LunarPhaseData;
 import com.mrbysco.lunar.api.ILunarEvent;
 import com.mrbysco.lunar.handler.result.EventResult;
+import com.mrbysco.lunar.registry.LunarRegistry;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.LivingEntity;
@@ -20,7 +21,12 @@ public class LunarHandler {
 
 			if (currentTime > 13000 && currentTime < 23000) {
 				if (!phaseData.hasEventActive()) {
-					phaseData.setRandomLunarEvent(serverLevel);
+
+					if(!phaseData.setPhaseEvent(serverLevel)){
+						if(!phaseData.setDayEvent(serverLevel)){
+							phaseData.setRandomLunarEvent(serverLevel); //I'm not sure I'm *that* happy with how this looks, but it's the best way I could think to do it so
+						}
+					}
 					phaseData.syncEvent(serverLevel);
 				} else {
 					if (event != null) {

--- a/common/src/main/java/com/mrbysco/lunar/platform/services/IPlatformHelper.java
+++ b/common/src/main/java/com/mrbysco/lunar/platform/services/IPlatformHelper.java
@@ -162,6 +162,13 @@ public interface IPlatformHelper {
 	int getHeroMoonPhase();
 
 	/**
+	 * Returns the configured phase of the Eclipse Moon event.
+	 *
+	 * @return the Eclipse Moon Phase
+	 */
+	int getEclipseMoonPhase();
+
+	/**
 	 * Returns the configured nth day of the Blood Moon event.
 	 *
 	 * @return the Blood Moon Day
@@ -216,6 +223,13 @@ public interface IPlatformHelper {
 	 * @return the Hero Moon Day
 	 */
 	int getHeroMoonDay();
+
+	/**
+	 * Returns the configured nth day of the Eclipse Moon event.
+	 *
+	 * @return the Eclipse Moon Day
+	 */
+	int getEclipseMoonDay();
 
 	/**
 	 * Returns the configured Crimson Replacement Map to be used during the Crimson Moon event

--- a/common/src/main/java/com/mrbysco/lunar/platform/services/IPlatformHelper.java
+++ b/common/src/main/java/com/mrbysco/lunar/platform/services/IPlatformHelper.java
@@ -106,6 +106,118 @@ public interface IPlatformHelper {
 	int getEclipseMoonWeight();
 
 	/**
+	 * Returns the configured phase of the Blood Moon event.
+	 *
+	 * @return the Blood Moon Phase
+	 */
+	int getBloodMoonPhase();
+
+	/**
+	 * Returns the configured phase of the Crimson Moon event.
+	 *
+	 * @return the Crimson Moon Phase
+	 */
+	int getCrimsonMoonPhase();
+
+	/**
+	 * Returns the configured phase of the Miner Moon event.
+	 *
+	 * @return the Miner Moon Phase
+	 */
+	int getMinerMoonPhase();
+
+	/**
+	 * Returns the configured phase of the White Moon event.
+	 *
+	 * @return the White Moon Phase
+	 */
+	int getWhiteMoonPhase();
+
+	/**
+	 * Returns the configured phase of the Big Moon event.
+	 *
+	 * @return the Big Moon Phase
+	 */
+	int getBigMoonPhase();
+
+	/**
+	 * Returns the configured phase of the Tiny Moon event.
+	 *
+	 * @return the Tiny Moon Phase
+	 */
+	int getTinyMoonPhase();
+
+	/**
+	 * Returns the configured phase of the Bad Omen Moon event.
+	 *
+	 * @return the Bad Omen Moon Phase
+	 */
+	int getBadOmenMoonPhase();
+
+	/**
+	 * Returns the configured phase of the Hero Moon event.
+	 *
+	 * @return the Hero Moon Phase
+	 */
+	int getHeroMoonPhase();
+
+	/**
+	 * Returns the configured nth day of the Blood Moon event.
+	 *
+	 * @return the Blood Moon Day
+	 */
+	int getBloodMoonDay();
+
+	/**
+	 * Returns the configured nth day of the Crimson Moon event.
+	 *
+	 * @return the Crimson Moon Day
+	 */
+	int getCrimsonMoonDay();
+
+	/**
+	 * RReturns the configured nth day of the Miner Moon event.
+	 *
+	 * @return the Miner Moon Day
+	 */
+	int getMinerMoonDay();
+
+	/**
+	 * Returns the configured nth day of the White Moon event.
+	 *
+	 * @return the White Moon Day
+	 */
+	int getWhiteMoonDay();
+
+	/**
+	 * Returns the configured nth day of the Big Moon event.
+	 *
+	 * @return the Big Moon Day
+	 */
+	int getBigMoonDay();
+
+	/**
+	 * Returns the configured nth day of the Tiny Moon event.
+	 *
+	 * @return the Tiny Moon Day
+	 */
+	int getTinyMoonDay();
+
+	/**
+	 * Returns the configured nth day of the Bad Omen Moon event.
+	 *
+	 * @return the Bad Omen Moon Day
+	 */
+	int getBadOmenMoonDay();
+
+	/**
+	 * Returns the configured nth day of the Hero Moon event.
+	 *
+	 * @return the Hero Moon Day
+	 */
+	int getHeroMoonDay();
+
+	/**
 	 * Returns the configured Crimson Replacement Map to be used during the Crimson Moon event
 	 *
 	 * @return the configured Crimson Replacement Map.

--- a/common/src/main/java/com/mrbysco/lunar/registry/LunarRegistry.java
+++ b/common/src/main/java/com/mrbysco/lunar/registry/LunarRegistry.java
@@ -111,7 +111,7 @@ public class LunarRegistry {
 	}
 
 	public ILunarEvent getPhaseEvent(Level level) {
-		List<ILunarEvent> phaseEventListCopy = new ArrayList<>(eventList);
+		List<ILunarEvent> phaseEventListCopy = new ArrayList<>(phaseEventList);
 
 		for(ILunarEvent i : phaseEventListCopy){
 			if(level.getMoonPhase() == i.getPhase()){
@@ -123,10 +123,10 @@ public class LunarRegistry {
 	}
 
 	public ILunarEvent getDayEvent(Level level) {
-		List<ILunarEvent> dayEventListCopy = new ArrayList<>(eventList);
+		List<ILunarEvent> dayEventListCopy = new ArrayList<>(dayEventList);
 
 		for(ILunarEvent i : dayEventListCopy){
-			if(level.getDayTime() / 24000 == i.getDay()){
+			if((level.getDayTime() / 24000) % i.getDay() == 0){
 				return i;
 			}
 		}

--- a/common/src/main/java/com/mrbysco/lunar/registry/LunarRegistry.java
+++ b/common/src/main/java/com/mrbysco/lunar/registry/LunarRegistry.java
@@ -25,6 +25,8 @@ public class LunarRegistry {
 	private static LunarRegistry INSTANCE;
 	private final Map<ResourceLocation, ILunarEvent> eventMap = Maps.newHashMap();
 	private final List<ILunarEvent> eventList = new ArrayList<>();
+	private final List<ILunarEvent> dayEventList = new ArrayList<>();
+	private final List<ILunarEvent> phaseEventList = new ArrayList<>();
 
 	public static LunarRegistry instance() {
 		if (INSTANCE == null)
@@ -61,6 +63,14 @@ public class LunarRegistry {
 			Constants.LOGGER.debug("Adding Lunar Event: {}", id.toString());
 			eventMap.put(id, event);
 			eventList.add(event);
+
+			if(event.getPhase() != -1){
+				phaseEventList.add(event);
+			}
+
+			if(event.getDay() != 0){
+				dayEventList.add(event);
+			}
 		} else {
 			Constants.LOGGER.error("Failed to add lunar event. There was an attempt to add duplicate lunar event {} of class {}", id, event.getClass().getName());
 		}
@@ -99,6 +109,38 @@ public class LunarRegistry {
 		}
 		return eventCopy.get(randomIndex);
 	}
+
+	public ILunarEvent getPhaseEvent(Level level) {
+		List<ILunarEvent> phaseEventListCopy = new ArrayList<>(eventList);
+
+		for(ILunarEvent i : phaseEventListCopy){
+			if(level.getMoonPhase() == i.getPhase()){
+				return i;
+			}
+		}
+
+		return null;
+	}
+
+	public ILunarEvent getDayEvent(Level level) {
+		List<ILunarEvent> dayEventListCopy = new ArrayList<>(eventList);
+
+		for(ILunarEvent i : dayEventListCopy){
+			if(level.getDayTime() / 24000 == i.getDay()){
+				return i;
+			}
+		}
+
+		return null;
+	}
+
+	public boolean phaseConfigured() {
+		return !phaseEventList.isEmpty();
+	}
+
+	public boolean dayConfigured() {
+        return !dayEventList.isEmpty();
+    }
 
 	public List<String> getIDList() {
 		List<String> list = new ArrayList<>();

--- a/common/src/main/java/com/mrbysco/lunar/registry/events/BadOmenMoonEvent.java
+++ b/common/src/main/java/com/mrbysco/lunar/registry/events/BadOmenMoonEvent.java
@@ -23,6 +23,16 @@ public class BadOmenMoonEvent extends LunarEvent {
 	}
 
 	@Override
+	public int getPhase() {
+		return Services.PLATFORM.getBadOmenMoonPhase();
+	}
+
+	@Override
+	public int getDay() {
+		return Services.PLATFORM.getBadOmenMoonDay();
+	}
+
+	@Override
 	public String getTranslationKey() {
 		return "lunar.event.bad_omen_moon";
 	}

--- a/common/src/main/java/com/mrbysco/lunar/registry/events/BigMoonEvent.java
+++ b/common/src/main/java/com/mrbysco/lunar/registry/events/BigMoonEvent.java
@@ -22,6 +22,16 @@ public class BigMoonEvent extends LunarEvent {
 	}
 
 	@Override
+	public int getPhase() {
+		return Services.PLATFORM.getBigMoonPhase();
+	}
+
+	@Override
+	public int getDay() {
+		return Services.PLATFORM.getBigMoonDay();
+	}
+
+	@Override
 	public String getTranslationKey() {
 		return "lunar.event.big_moon";
 	}

--- a/common/src/main/java/com/mrbysco/lunar/registry/events/BloodMoonEvent.java
+++ b/common/src/main/java/com/mrbysco/lunar/registry/events/BloodMoonEvent.java
@@ -33,6 +33,16 @@ public class BloodMoonEvent extends LunarEvent {
 	}
 
 	@Override
+	public int getPhase() {
+		return Services.PLATFORM.getBloodMoonPhase();
+	}
+
+	@Override
+	public int getDay() {
+		return Services.PLATFORM.getBloodMoonDay();
+	}
+
+	@Override
 	public String getTranslationKey() {
 		return "lunar.event.blood_moon";
 	}

--- a/common/src/main/java/com/mrbysco/lunar/registry/events/CrimsonMoonEvent.java
+++ b/common/src/main/java/com/mrbysco/lunar/registry/events/CrimsonMoonEvent.java
@@ -29,6 +29,16 @@ public class CrimsonMoonEvent extends LunarEvent {
 	}
 
 	@Override
+	public int getPhase() {
+		return Services.PLATFORM.getCrimsonMoonPhase();
+	}
+
+	@Override
+	public int getDay() {
+		return Services.PLATFORM.getCrimsonMoonDay();
+	}
+
+	@Override
 	public String getTranslationKey() {
 		return "lunar.event.crimson_moon";
 	}

--- a/common/src/main/java/com/mrbysco/lunar/registry/events/EclipseMoonEvent.java
+++ b/common/src/main/java/com/mrbysco/lunar/registry/events/EclipseMoonEvent.java
@@ -23,6 +23,16 @@ public class EclipseMoonEvent extends LunarEvent {
 	}
 
 	@Override
+	public int getPhase() {
+		return Services.PLATFORM.getEclipseMoonPhase();
+	}
+
+	@Override
+	public int getDay() {
+		return Services.PLATFORM.getEclipseMoonDay();
+	}
+
+	@Override
 	public String getTranslationKey() {
 		return "lunar.event.eclipse_moon";
 	}

--- a/common/src/main/java/com/mrbysco/lunar/registry/events/HeroMoonEvent.java
+++ b/common/src/main/java/com/mrbysco/lunar/registry/events/HeroMoonEvent.java
@@ -23,6 +23,16 @@ public class HeroMoonEvent extends LunarEvent {
 	}
 
 	@Override
+	public int getPhase() {
+		return Services.PLATFORM.getHeroMoonPhase();
+	}
+
+	@Override
+	public int getDay() {
+		return Services.PLATFORM.getHeroMoonDay();
+	}
+
+	@Override
 	public String getTranslationKey() {
 		return "lunar.event.hero_moon";
 	}

--- a/common/src/main/java/com/mrbysco/lunar/registry/events/MinerMoonEvent.java
+++ b/common/src/main/java/com/mrbysco/lunar/registry/events/MinerMoonEvent.java
@@ -22,6 +22,16 @@ public class MinerMoonEvent extends LunarEvent {
 	}
 
 	@Override
+	public int getPhase() {
+		return Services.PLATFORM.getMinerMoonPhase();
+	}
+
+	@Override
+	public int getDay() {
+		return Services.PLATFORM.getMinerMoonDay();
+	}
+
+	@Override
 	public String getTranslationKey() {
 		return "lunar.event.miner_moon";
 	}

--- a/common/src/main/java/com/mrbysco/lunar/registry/events/RegularMoonEvent.java
+++ b/common/src/main/java/com/mrbysco/lunar/registry/events/RegularMoonEvent.java
@@ -19,6 +19,12 @@ public class RegularMoonEvent extends LunarEvent {
 	}
 
 	@Override
+	public int getPhase() { return 0; }
+
+	@Override
+	public int getDay() { return 0; }
+
+	@Override
 	public String getTranslationKey() {
 		return "lunar.event.regular";
 	}

--- a/common/src/main/java/com/mrbysco/lunar/registry/events/TinyMoonEvent.java
+++ b/common/src/main/java/com/mrbysco/lunar/registry/events/TinyMoonEvent.java
@@ -23,6 +23,16 @@ public class TinyMoonEvent extends LunarEvent {
 	}
 
 	@Override
+	public int getPhase() {
+		return Services.PLATFORM.getTinyMoonPhase();
+	}
+
+	@Override
+	public int getDay() {
+		return Services.PLATFORM.getTinyMoonDay();
+	}
+
+	@Override
 	public String getTranslationKey() {
 		return "lunar.event.tiny_moon";
 	}

--- a/common/src/main/java/com/mrbysco/lunar/registry/events/WhiteMoonEvent.java
+++ b/common/src/main/java/com/mrbysco/lunar/registry/events/WhiteMoonEvent.java
@@ -23,6 +23,16 @@ public class WhiteMoonEvent extends LunarEvent {
 	}
 
 	@Override
+	public int getPhase() {
+		return Services.PLATFORM.getWhiteMoonPhase();
+	}
+
+	@Override
+	public int getDay() {
+		return Services.PLATFORM.getWhiteMoonDay();
+	}
+
+	@Override
 	public String getTranslationKey() {
 		return "lunar.event.white_moon";
 	}

--- a/fabric/src/main/java/com/mrbysco/lunar/config/LunarConfig.java
+++ b/fabric/src/main/java/com/mrbysco/lunar/config/LunarConfig.java
@@ -24,6 +24,9 @@ public class LunarConfig implements ConfigData {
 	@CollapsibleObject
 	public Phases phases = new Phases();
 
+	@CollapsibleObject
+	public Days days = new Days();
+
 	public static class General {
 		//General
 		@Comment("Chance of a Lunar Event happening when night falls [Default: 0.4]")
@@ -141,9 +144,9 @@ public class LunarConfig implements ConfigData {
 		@BoundedDiscrete(min = 0, max = 255)
 		public int heroMoonDay = 0;
 
-		@Comment("Triggers the Crimson Moon every number of days, as defined. [Default: 0; Disabled]")
+		@Comment("Triggers the Eclipse Moon every number of days, as defined. [Default: 0; Disabled]")
 		@BoundedDiscrete(min = 0, max = 255)
-		public int crimsonMoonDay = 0;
+		public int eclipseMoonDay = 0;
 	}
 
 	public static class Crimson {

--- a/fabric/src/main/java/com/mrbysco/lunar/config/LunarConfig.java
+++ b/fabric/src/main/java/com/mrbysco/lunar/config/LunarConfig.java
@@ -21,6 +21,9 @@ public class LunarConfig implements ConfigData {
 	@CollapsibleObject
 	public Crimson crimson = new Crimson();
 
+	@CollapsibleObject
+	public Phases phases = new Phases();
+
 	public static class General {
 		//General
 		@Comment("Chance of a Lunar Event happening when night falls [Default: 0.4]")
@@ -65,6 +68,82 @@ public class LunarConfig implements ConfigData {
 		@Comment("Weight of the Eclipse Moon Event [Default: 2]")
 		@BoundedDiscrete(min = 0, max = 100)
 		public int eclipseMoonWeight = 2;
+	}
+
+	public static class Phases {
+		@Comment("Moon phase that the Blood Moon should trigger on. [Default: -1]")
+		@BoundedDiscrete(min = -1, max = 7)
+		public int bloodMoonPhase = -1;
+
+		@Comment("Moon phase that the Crimson Moon should trigger on. [Default: -1]")
+		@BoundedDiscrete(min = -1, max = 7)
+		public int crimsonMoonPhase = -1;
+
+		@Comment("Moon phase that the Miner Moon should trigger on. [Default: -1]")
+		@BoundedDiscrete(min = -1, max = 7)
+		public int minerMoonPhase = -1;
+
+		@Comment("Moon phase that the White Moon should trigger on. [Default: -1]")
+		@BoundedDiscrete(min = -1, max = 7)
+		public int whiteMoonPhase = -1;
+
+		@Comment("Moon phase that the Tiny Moon should trigger on. [Default: -1]")
+		@BoundedDiscrete(min = -1, max = 7)
+		public int tinyMoonPhase = -1;
+
+		@Comment("Moon phase that the Big Moon should trigger on. [Default: -1]")
+		@BoundedDiscrete(min = -1, max = 7)
+		public int bigMoonPhase = -1;
+
+		@Comment("Moon phase that the Bad Omen Moon should trigger on. [Default: -1]")
+		@BoundedDiscrete(min = -1, max = 7)
+		public int badOmenMoonPhase = -1;
+
+		@Comment("Moon phase that the Hero Moon should trigger on. [Default: -1]")
+		@BoundedDiscrete(min = -1, max = 7)
+		public int heroMoonPhase = -1;
+
+		@Comment("Moon phase that the Eclipse Moon should trigger on. [Default: -1]")
+		@BoundedDiscrete(min = -1, max = 7)
+		public int eclipseMoonPhase = -1;
+	}
+
+	public static class Days {
+		@Comment("Triggers the Blood Moon every number of days, as defined. [Default: 0; Disabled]")
+		@BoundedDiscrete(min = 0, max = 255)
+		public int bloodMoonDay = 0;
+
+		@Comment("Triggers the Crimson Moon every number of days, as defined. [Default: 0; Disabled]")
+		@BoundedDiscrete(min = 0, max = 255)
+		public int crimsonMoonDay = 0;
+
+		@Comment("Triggers the Miner Moon every number of days, as defined. [Default: 0; Disabled]")
+		@BoundedDiscrete(min = 0, max = 255)
+		public int minerMoonDay = 0;
+
+		@Comment("Triggers the White Moon every number of days, as defined. [Default: 0; Disabled]")
+		@BoundedDiscrete(min = 0, max = 255)
+		public int whiteMoonDay = 0;
+
+		@Comment("Triggers the Big Moon every number of days, as defined. [Default: 0; Disabled]")
+		@BoundedDiscrete(min = 0, max = 255)
+		public int bigMoonDay = 0;
+
+		@Comment("Triggers the Tiny Moon every number of days, as defined. [Default: 0; Disabled]")
+		@BoundedDiscrete(min = 0, max = 255)
+		public int tinyMoonDay = 0;
+
+		@Comment("Triggers the Bad Omen Moon every number of days, as defined. [Default: 0; Disabled]")
+		@BoundedDiscrete(min = 0, max = 255)
+		public int badOmenMoonDay = 0;
+
+		@Comment("Triggers the Hero Moon every number of days, as defined. [Default: 0; Disabled]")
+		@BoundedDiscrete(min = 0, max = 255)
+		public int heroMoonDay = 0;
+
+		@Comment("Triggers the Crimson Moon every number of days, as defined. [Default: 0; Disabled]")
+		@BoundedDiscrete(min = 0, max = 255)
+		public int crimsonMoonDay = 0;
 	}
 
 	public static class Crimson {

--- a/fabric/src/main/java/com/mrbysco/lunar/platform/FabricPlatformHelper.java
+++ b/fabric/src/main/java/com/mrbysco/lunar/platform/FabricPlatformHelper.java
@@ -123,6 +123,114 @@ public class FabricPlatformHelper implements IPlatformHelper {
 	}
 
 	@Override
+	public int getBloodMoonPhase() {
+		if (Lunar.config == null) Lunar.config = AutoConfig.getConfigHolder(LunarConfig.class).getConfig();
+		return Lunar.config.phases.bloodMoonPhase;
+	}
+
+	@Override
+	public int getCrimsonMoonPhase() {
+		if (Lunar.config == null) Lunar.config = AutoConfig.getConfigHolder(LunarConfig.class).getConfig();
+		return Lunar.config.phases.crimsonMoonPhase;
+	}
+
+	@Override
+	public int getMinerMoonPhase() {
+		if (Lunar.config == null) Lunar.config = AutoConfig.getConfigHolder(LunarConfig.class).getConfig();
+		return Lunar.config.phases.minerMoonPhase;
+	}
+
+	@Override
+	public int getWhiteMoonPhase() {
+		if (Lunar.config == null) Lunar.config = AutoConfig.getConfigHolder(LunarConfig.class).getConfig();
+		return Lunar.config.phases.whiteMoonPhase;
+	}
+
+	@Override
+	public int getTinyMoonPhase() {
+		if (Lunar.config == null) Lunar.config = AutoConfig.getConfigHolder(LunarConfig.class).getConfig();
+		return Lunar.config.phases.tinyMoonPhase;
+	}
+
+	@Override
+	public int getBigMoonPhase() {
+		if (Lunar.config == null) Lunar.config = AutoConfig.getConfigHolder(LunarConfig.class).getConfig();
+		return Lunar.config.phases.bigMoonPhase;
+	}
+
+	@Override
+	public int getBadOmenMoonPhase() {
+		if (Lunar.config == null) Lunar.config = AutoConfig.getConfigHolder(LunarConfig.class).getConfig();
+		return Lunar.config.phases.badOmenMoonPhase;
+	}
+
+	@Override
+	public int getHeroMoonPhase() {
+		if (Lunar.config == null) Lunar.config = AutoConfig.getConfigHolder(LunarConfig.class).getConfig();
+		return Lunar.config.phases.heroMoonPhase;
+	}
+
+	@Override
+	public int getEclipseMoonPhase() {
+		if (Lunar.config == null) Lunar.config = AutoConfig.getConfigHolder(LunarConfig.class).getConfig();
+		return Lunar.config.phases.eclipseMoonPhase;
+	}
+
+	@Override
+	public int getBloodMoonDay() {
+		if (Lunar.config == null) Lunar.config = AutoConfig.getConfigHolder(LunarConfig.class).getConfig();
+		return Lunar.config.days.bloodMoonDay;
+	}
+
+	@Override
+	public int getCrimsonMoonDay() {
+		if (Lunar.config == null) Lunar.config = AutoConfig.getConfigHolder(LunarConfig.class).getConfig();
+		return Lunar.config.days.crimsonMoonDay;
+	}
+
+	@Override
+	public int getMinerMoonDay() {
+		if (Lunar.config == null) Lunar.config = AutoConfig.getConfigHolder(LunarConfig.class).getConfig();
+		return Lunar.config.days.minerMoonDay;
+	}
+
+	@Override
+	public int getWhiteMoonDay() {
+		if (Lunar.config == null) Lunar.config = AutoConfig.getConfigHolder(LunarConfig.class).getConfig();
+		return Lunar.config.days.whiteMoonDay;
+	}
+
+	@Override
+	public int getBigMoonDay() {
+		if (Lunar.config == null) Lunar.config = AutoConfig.getConfigHolder(LunarConfig.class).getConfig();
+		return Lunar.config.days.bigMoonDay;
+	}
+
+	@Override
+	public int getTinyMoonDay() {
+		if (Lunar.config == null) Lunar.config = AutoConfig.getConfigHolder(LunarConfig.class).getConfig();
+		return Lunar.config.days.tinyMoonDay;
+	}
+
+	@Override
+	public int getBadOmenMoonDay() {
+		if (Lunar.config == null) Lunar.config = AutoConfig.getConfigHolder(LunarConfig.class).getConfig();
+		return Lunar.config.days.badOmenMoonDay;
+	}
+
+	@Override
+	public int getHeroMoonDay() {
+		if (Lunar.config == null) Lunar.config = AutoConfig.getConfigHolder(LunarConfig.class).getConfig();
+		return Lunar.config.days.heroMoonDay;
+	}
+
+	@Override
+	public int getEclipseMoonDay() {
+		if (Lunar.config == null) Lunar.config = AutoConfig.getConfigHolder(LunarConfig.class).getConfig();
+		return Lunar.config.days.eclipseMoonDay;
+	}
+
+	@Override
 	public Map<ResourceLocation, ResourceLocation> getCrimsonReplacementMap() {
 		if (Lunar.config == null) Lunar.config = AutoConfig.getConfigHolder(LunarConfig.class).getConfig();
 		Map<ResourceLocation, ResourceLocation> map = Maps.newHashMap();

--- a/forge/src/main/java/com/mrbysco/lunar/config/LunarConfig.java
+++ b/forge/src/main/java/com/mrbysco/lunar/config/LunarConfig.java
@@ -22,6 +22,25 @@ public class LunarConfig {
 		public final IntValue badOmenMoonWeight;
 		public final IntValue heroMoonWeight;
 		public final IntValue eclipseMoonWeight;
+		public final IntValue bloodMoonPhase;
+		public final IntValue crimsonMoonPhase;
+		public final IntValue minerMoonPhase;
+		public final IntValue whiteMoonPhase;
+		public final IntValue bigMoonPhase;
+		public final IntValue tinyMoonPhase;
+		public final IntValue badOmenMoonPhase;
+		public final IntValue heroMoonPhase;
+		public final IntValue eclipseMoonPhase;
+		public final IntValue bloodMoonDay;
+		public final IntValue crimsonMoonDay;
+		public final IntValue minerMoonDay;
+		public final IntValue whiteMoonDay;
+		public final IntValue bigMoonDay;
+		public final IntValue tinyMoonDay;
+		public final IntValue badOmenMoonDay;
+		public final IntValue heroMoonDay;
+		public final IntValue eclipseMoonDay;
+
 
 		public final ConfigValue<List<? extends String>> crimsonReplacements;
 
@@ -72,6 +91,86 @@ public class LunarConfig {
 			eclipseMoonWeight = builder
 					.comment("Weight of the Eclipse Moon Event [Default: 2]")
 					.defineInRange("eclipseMoonWeight", 2, 0, 100);
+
+			builder.pop();
+			builder.comment("Moon phase settings. -1 is disabled, 0-7 are moon phases, starting with a full moon at 0.")
+					.push("Phases");
+
+			bloodMoonPhase = builder
+					.comment("Moon phase that the Blood Moon should trigger on. [Default: -1]")
+					.defineInRange("bloodMoonPhase", -1, -1, 7);
+
+			crimsonMoonPhase = builder
+					.comment("Moon phase that the Crimson Moon should trigger on. [Default: -1]")
+					.defineInRange("crimsonMoonPhase", -1, -1, 7);
+
+			minerMoonPhase = builder
+					.comment("Moon phase that the Miner Moon should trigger on. [Default: -1]")
+					.defineInRange("minerMoonPhase", -1, -1, 7);
+
+			whiteMoonPhase = builder
+					.comment("Moon phase that the White Moon should trigger on. [Default: -1]")
+					.defineInRange("whiteMoonPhase", -1, -1, 7);
+
+			bigMoonPhase = builder
+					.comment("Moon phase that the Big Moon should trigger on. [Default: -1]")
+					.defineInRange("bigMoonPhase", -1, -1, 7);
+
+			tinyMoonPhase = builder
+					.comment("Moon phase that the Tiny Moon should trigger on. [Default: -1]")
+					.defineInRange("tinyMoonPhase", -1, -1, 7);
+
+			badOmenMoonPhase = builder
+					.comment("Moon phase that the Bad Omen Moon should trigger on. [Default: -1]")
+					.defineInRange("badOmenMoonPhase", -1, -1, 7);
+
+			heroMoonPhase = builder
+					.comment("Moon phase that the Hero Moon should trigger on. [Default: -1]")
+					.defineInRange("heroMoonPhase", -1, -1, 7);
+
+			eclipseMoonPhase = builder
+					.comment("Moon phase that the Eclipse Moon should trigger on. [Default: -1]")
+					.defineInRange("eclipseMoonPhase", -1, -1, 7);
+
+			builder.pop();
+			builder.comment("Lunar event day settings. 0 is disabled, anything above is enabled.")
+					.push("Days");
+
+			bloodMoonDay = builder
+					.comment("Triggers the Blood Moon every number of days, as defined. [Default: 0]")
+					.defineInRange("bloodMoonDay", 0, 0, 255);
+
+			crimsonMoonDay = builder
+					.comment("Triggers the Crimson Moon every number of days, as defined. [Default: 0]")
+					.defineInRange("crimsonMoonDay", 0, 0, 255);
+
+			minerMoonDay = builder
+					.comment("Triggers the Miner Moon every number of days, as defined. [Default: 0]")
+					.defineInRange("minerMoonDay", 0, 0, 255);
+
+			whiteMoonDay = builder
+					.comment("Triggers the White Moon every number of days, as defined. [Default: 0]")
+					.defineInRange("whiteMoonDay", 0, 0, 255);
+
+			bigMoonDay = builder
+					.comment("Triggers the Big Moon every number of days, as defined. [Default: 0]")
+					.defineInRange("bigMoonDay", 0, 0, 255);
+
+			tinyMoonDay = builder
+					.comment("Triggers the Tiny Moon every number of days, as defined. [Default: 0]")
+					.defineInRange("tinyMoonDay", 0, 0, 255);
+
+			badOmenMoonDay = builder
+					.comment("Triggers the Bad Omen Moon every number of days, as defined. [Default: 0]")
+					.defineInRange("badOmenMoonDay", 0, 0, 255);
+
+			heroMoonDay = builder
+					.comment("Triggers the Hero Moon every number of days, as defined. [Default: 0]")
+					.defineInRange("heroMoonDay", 0, 0, 255);
+
+			eclipseMoonDay = builder
+					.comment("Triggers the Eclipse Moon every number of days, as defined. [Default: 0]")
+					.defineInRange("eclipseMoonDay", 0, 0, 255);
 
 			builder.pop();
 			builder.comment("Crimson Replacement settings")

--- a/forge/src/main/java/com/mrbysco/lunar/platform/ForgePlatformHelper.java
+++ b/forge/src/main/java/com/mrbysco/lunar/platform/ForgePlatformHelper.java
@@ -1,6 +1,7 @@
 package com.mrbysco.lunar.platform;
 
 import com.google.common.collect.Maps;
+import com.mrbysco.lunar.Lunar;
 import com.mrbysco.lunar.api.ILunarEvent;
 import com.mrbysco.lunar.config.LunarConfig;
 import com.mrbysco.lunar.network.PacketHandler;
@@ -83,6 +84,62 @@ public class ForgePlatformHelper implements IPlatformHelper {
 	public int getEclipseMoonWeight() {
 		return LunarConfig.COMMON.eclipseMoonWeight.get();
 	}
+
+	@Override
+	public int getBloodMoonPhase() {
+		return LunarConfig.COMMON.bloodMoonPhase.get();
+	}
+
+	@Override
+	public int getCrimsonMoonPhase() { return LunarConfig.COMMON.crimsonMoonPhase.get(); }
+
+	@Override
+	public int getMinerMoonPhase() { return LunarConfig.COMMON.minerMoonPhase.get(); }
+
+	@Override
+	public int getWhiteMoonPhase() { return LunarConfig.COMMON.whiteMoonPhase.get(); }
+
+	@Override
+	public int getTinyMoonPhase() { return LunarConfig.COMMON.tinyMoonPhase.get(); }
+
+	@Override
+	public int getBigMoonPhase() { return LunarConfig.COMMON.bigMoonPhase.get(); }
+
+	@Override
+	public int getBadOmenMoonPhase() { return LunarConfig.COMMON.badOmenMoonPhase.get(); }
+
+	@Override
+	public int getHeroMoonPhase() { return LunarConfig.COMMON.heroMoonPhase.get(); }
+
+	@Override
+	public int getEclipseMoonPhase() { return LunarConfig.COMMON.eclipseMoonPhase.get(); }
+
+	@Override
+	public int getBloodMoonDay() { return LunarConfig.COMMON.bloodMoonDay.get(); }
+
+	@Override
+	public int getCrimsonMoonDay() { return LunarConfig.COMMON.crimsonMoonDay.get(); }
+
+	@Override
+	public int getMinerMoonDay() { return LunarConfig.COMMON.minerMoonDay.get(); }
+
+	@Override
+	public int getWhiteMoonDay() { return LunarConfig.COMMON.whiteMoonDay.get(); }
+
+	@Override
+	public int getBigMoonDay() { return LunarConfig.COMMON.bigMoonDay.get(); }
+
+	@Override
+	public int getTinyMoonDay() { return LunarConfig.COMMON.tinyMoonDay.get(); }
+
+	@Override
+	public int getBadOmenMoonDay() { return LunarConfig.COMMON.badOmenMoonDay.get(); }
+
+	@Override
+	public int getHeroMoonDay() { return LunarConfig.COMMON.heroMoonDay.get(); }
+
+	@Override
+	public int getEclipseMoonDay() { return LunarConfig.COMMON.eclipseMoonDay.get(); }
 
 	@Override
 	public Map<ResourceLocation, ResourceLocation> getCrimsonReplacementMap() {


### PR DESCRIPTION
As per #7, moon phases can now be configured to specific phases and/or certain days. From the testing I've done, it *should* work on both Forge and Fabric as intended, though obviously a double check wouldn't hurt 🙂‍↕️

There two things I thought about implementing but didn't, as I figured they'd probably benefit from discussion first:
- How should nights where two possible events could be picked be handled?
  - As is?
  - Random chance?
  - By weight? If so, reverse or regular order? Configurable?
- Should events with a weight of zero even be considered for phase/day calculations?

Also, apologies for the first few commits where I missed some of the settings.. Like I said in the descriptions, they're repetitive enough that I accidentally missed them 😞